### PR TITLE
Bugfix: sfw.furaffinity.net links wouldn't mirror

### DIFF
--- a/plugins/furaffinity.py
+++ b/plugins/furaffinity.py
@@ -50,7 +50,7 @@ class FurAffinityPlugin:
         self.headers = {'User-Agent': useragent}
         self.regex = re.compile(
             r'^https?://('
-            r'((?:www\.)?furaffinity\.net/view/(?P<id>\d+).*)|'
+            r'((?:www\.)?(?:sfw\.)?furaffinity\.net/view/(?P<id>\d+).*)|'
             r'(d\.facdn\.net/art/(?P<artist>[^/]+)/(?P<cdn_id>\d+)/.*)'
             r')$')
 


### PR DESCRIPTION
The SFW subdomain for FurAffinity, `sfw.furaffinity.net`, would not mirror. This fixes that. Currently operational on /u/TheMirrorPool.

[Example](https://www.reddit.com/r/heyitsshugatest/comments/4x3n4p/fatestlapismirror/)

PS: Sorry for the .com in the commit name, it's meaningless.
