### PR TITLE
Plugin: Derpibooru

### DIFF
--- a/plugins/derpibooru.py
+++ b/plugins/derpibooru.py
@@ -1,0 +1,110 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2015 kupiakos
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import logging
+import re
+import html
+from urllib.parse import urlsplit
+import traceback
+
+import json
+import requests
+import mimeparse
+import praw
+
+
+class DerpibooruPlugin:
+    """
+    Mirrors Derpibooru images.
+    Created by /u/HeyItsShuga
+
+    """
+
+    def __init__(self, useragent: str, **options):
+        """Initialize the Derpibooru importer.
+
+        :param useragent: The useragent to use for querying derpibooru.
+        :param options: Other options in the configuration. Ignored.
+        """
+        self.log = logging.getLogger('lapis.derpibooru')
+        self.headers = {'User-Agent': useragent}
+        self.regex = re.compile(r'(www\.)?(derpiboo\.ru)|(derpibooru\.org)|(derpicdn\.net)$')
+
+    def import_submission(self, submission: praw.objects.Submission) -> dict:
+        """Import a submission from Derpibooru.
+
+        This function will define the following values in its return data:
+        - author: simply "an anonymous user on Derpibooru"
+        - source: The url of the submission
+        - importer_display/header
+        - import_urls
+
+        After we define that, we need to get the image. Since Derpibooru has an API,
+        we use that to try to get the image if the image is a non-CDN URL. If it is
+        a CDN, we take the image directory and upload *that* to Imgur.
+
+        image_url is the variable of the image to upload.
+
+        :param submission: A reddit submission to parse.
+        """
+        try:
+            url = html.unescape(submission.url)
+            if not self.regex.match(urlsplit(url).netloc):
+                return None
+            r = requests.head(url, headers=self.headers)
+            mime_text = r.headers.get('Content-Type')
+            mime = mimeparse.parse_mime_type(mime_text)
+            if mime[0] == 'image':
+                self.log.debug('Is CDN, no API needed')
+                data = {'author': 'a Derpibooru user',
+                        'source': url,
+                        'importer_display':
+                            {'header': 'Mirrored Derpibooru image:\n\n'}}
+                image_url = url
+            else:
+                self.log.debug('Not CDN, will use API')
+                if url.endswith('/'): # If the URL ends with a slash (/), remove
+                     url = url[:-1]   #      it so the API works properly.
+                url, sep, trash = url.partition('#') # Removes junk data from URL.
+                url, sep, trash = url.partition('?') # Removes junk data from URL.
+                urlJ = url + '.json' # Allow the API endpoint to work.
+                self.log.debug('Will use API endpoint at ' + urlJ)
+                callapi = requests.get(urlJ) # These next lines uses the API...
+                json = callapi.json() # ...endpoint and gets the direct image URL to upload.
+                img = 'http:' + (json['image'])
+                uploader = (json['uploader'])
+                data = {'author': 'a Derpibooru user',
+                        'source': url,
+                        'importer_display':
+                            {'header': 'Mirrored Derpibooru image uploaded by ' + uploader + ':\n\n'}}
+                image_url = img # image_url is the image being mirrored.
+            data['import_urls'] = [image_url]
+            return data
+        except Exception:
+            self.log.error('Could not import Derpibooru URL %s (%s)',
+                           submission.url, traceback.format_exc())
+            return None
+
+
+__plugin__ = DerpibooruPlugin
+
+# END OF LINE.

--- a/plugins/derpibooru.py
+++ b/plugins/derpibooru.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2015 kupiakos
+# Copyright (c) 2016 HeyItsShuga
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull requests adds a plugin to add support for Derpibooru, a booru-based site for fans of MLP:FiM. It does the following:
- Mirrors all images from Derpibooru and its CDN
- Retrieves the uploader for non-CDN Derpibooru images
- Uses the Derpibooru API for uploading non-CDN links and a direct link for CDN links.
- Affects https://derpiboo.ru, https://derpibooru.org, and https://derpicdn.net links

This plugin is active on /u/TheMirrorPool and can be seen in action [here](https://www.reddit.com/r/heyitsshugatest/comments/4xe4cj/_/).
