### PR TITLE
Plugin: e621 / e926

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Currently, Lapis Mirror imports from the following sites:
 * e621
 * e926
 
-
 It also exports to the following sites:
 * imgur for images
 * vid.me for videos (in addition to a direct link to the video)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Currently, Lapis Mirror imports from the following sites:
 * puu.sh
 * flickr
 * FurAffinity
+* Derpibooru
+* e621
+* e926
 
 It also exports to the following sites:
 * imgur for images

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -1,0 +1,113 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016 HeyItsShuga
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import logging
+import re
+import html
+from urllib.parse import urlsplit
+import traceback
+
+import json
+import requests
+import mimeparse
+import praw
+
+
+class e621Plugin:
+    """
+    Mirrors e621 images.
+    Created by /u/HeyItsShuga
+
+    """
+
+    def __init__(self, useragent: str, **options):
+        """Initialize the e621 importer.
+
+        :param useragent: The useragent to use for querying e621.
+        :param options: Other options in the configuration. Ignored.
+        """
+        self.log = logging.getLogger('lapis.e621')
+        self.headers = {'User-Agent': useragent}
+        self.regex = re.compile(r'^https?://(((?:www\.)?(?:static1\.)?((e621)|(e926))\.net/(data/.+/(?P<cdn_id>\w+))?(post/show/(?P<id>\d+)/?)?.*))$')
+
+    def import_submission(self, submission: praw.objects.Submission) -> dict:
+        """Import a submission from e621.
+
+        This function will define the following values in its return data:
+        - author: simply "an anonymous user on e621"
+        - source: The url of the submission
+        - importer_display/header
+        - import_urls
+
+        After we define that, we need to get the image. Since e621 has an API,
+        we use that to try to get the image if the image is a non-CDN URL. If it is
+        a CDN, we take the image directory and upload *that* to Imgur.
+
+        image_url is the variable of the image to upload.
+
+        :param submission: A reddit submission to parse.
+        """
+        print('e621 PLUGIN DEBUG - Initiated plugin.')
+        try:
+            url = html.unescape(submission.url)
+            match = self.regex.match(submission.url)
+            if not match:
+                print('e621 PLUGIN DEBUG - Regex failed') ####################
+                return None
+            print('e621 PLUGIN DEBUG - Regex suceeded') ####################
+            r = requests.head(url, headers=self.headers)
+            mime_text = r.headers.get('Content-Type')
+            mime = mimeparse.parse_mime_type(mime_text)
+            if mime[0] == 'image':
+                self.log.debug('Is CDN, no API needed')
+                data = {'author': 'a e926 user',
+                        'source': url,
+                        'importer_display':
+                            {'header': 'Mirrored e926 image:\n\n'}}
+                image_url = url
+            else:
+                self.log.debug('Not CDN, will use API')
+                match = self.regex.match(submission.url)
+                match_data = match.groupdict()
+                id = match_data.get('id') # Get ID out of regex.
+                urlJ = 'http://e926.net/post/show.json?id=' + id
+                self.log.debug('Will use API endpoint at ' + urlJ)
+                callapi = requests.get(urlJ) # These next lines uses the API...
+                json = callapi.json() # ...endpoint and gets the direct image URL to upload.
+                img = (json['file_url'])
+                uploader = (json['author'])
+                data = {'author': 'an e926 user',
+                        'source': url,
+                        'importer_display':
+                            {'header': 'Mirrored e926 image by ' + uploader + ':\n\n'}}
+                image_url = img # image_url is the image being mirrored.
+            data['import_urls'] = [image_url]
+            return data
+        except Exception:
+            self.log.error('Could not import e621 URL %s (%s)',
+                           submission.url, traceback.format_exc())
+            return None
+
+
+__plugin__ = e621Plugin
+
+# END OF LINE.

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -35,7 +35,6 @@ class E621Plugin:
     """
     Mirrors e621 images using either their API or using their CDN links.
     Created by /u/HeyItsShuga
-
     """
 
     def __init__(self, useragent: str, **options):

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -89,7 +89,7 @@ class E621Plugin:
                 # For non-CDN links, the plugin attempts to get the post_id
                 # out of the URL using regex.
                 post_id = match.group('post_id')
-                endpoint = 'http://e926.net/post/show.json?post_id=' + post_id
+                endpoint = 'http://e926.net/post/show.json?id=' + post_id
                 self.log.debug('Will use API endpoint at %s', endpoint)
                 # We will use the e621 API to get the image URL.
                 callapi = requests.get(endpoint)

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -49,7 +49,7 @@ class E621Plugin:
         self.regex = re.compile(
             r'^https?://(((?:www\.)?(?:static1\.)?'
             r'((e621)|(e926))\.net/(data/.+/(?P<cdn_id>\w+))?'
-            r'(post/show/(?P<id>\d+)/?)?.*))$')
+            r'(post/show/(?P<post_id>\d+)/?)?.*))$')
 
     def import_submission(self, submission: praw.objects.Submission) -> dict:
         """Import a submission from e621.
@@ -86,16 +86,15 @@ class E621Plugin:
                 image_url = url
             else:
                 self.log.debug('Using the e621 API')
-                match_data = match.groupdict()
-                # For non-CDN links, the plugin attempts to get the ID
+                # For non-CDN links, the plugin attempts to get the post_id
                 # out of the URL using regex.
-                id = match_data.get('id')
-                endpoint = 'http://e926.net/post/show.json?id=' + id
-                self.log.debug('Will use API endpoint at ' + endpoint)
+                post_id = match.group('post_id')
+                endpoint = 'http://e926.net/post/show.json?post_id=' + post_id
+                self.log.debug('Will use API endpoint at %s', endpoint)
                 # We will use the e621 API to get the image URL.
                 callapi = requests.get(endpoint)
                 json = callapi.json()
-                img = (json['file_url'])
+                img = json['file_url']
                 uploader = json['author']
                 data = {'author': uploader,
                         'source': url,

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -47,7 +47,7 @@ class E621Plugin:
         self.headers = {'User-Agent': useragent}
         self.regex = re.compile(
             r'^https?://(((?:www\.)?(?:static1\.)?'
-            r'((e621)|(e926))\.net/(data/.+/(?P<cdn_id>\w+))?'
+            r'(?P<service>(e621)|(e926))\.net/(data/.+/(?P<cdn_id>\w+))?'
             r'(post/show/(?P<post_id>\d+)/?)?.*))$')
 
     def import_submission(self, submission: praw.objects.Submission) -> dict:
@@ -78,17 +78,19 @@ class E621Plugin:
             mime = mimeparse.parse_mime_type(mime_text)
             if mime[0] == 'image':
                 self.log.debug('Using the CDN')
+                service = match.group('service')
                 data = {'author': 'a e926 user',
                         'source': url,
                         'importer_display':
-                            {'header': 'Mirrored e926 image:\n\n'}}
+                            {'header': 'Mirrored ' + service + ' image:\n\n'}}
                 image_url = url
             else:
                 self.log.debug('Using the e621 API')
                 # For non-CDN links, the plugin attempts to get the post_id
                 # out of the URL using regex.
                 post_id = match.group('post_id')
-                endpoint = 'http://e926.net/post/show.json?id=' + post_id
+                service = match.group('service')
+                endpoint = 'http://e621.net/post/show.json?id=' + post_id
                 self.log.debug('Will use API endpoint at %s', endpoint)
                 # We will use the e621 API to get the image URL.
                 callapi = requests.get(endpoint)
@@ -98,7 +100,7 @@ class E621Plugin:
                 data = {'author': uploader,
                         'source': url,
                         'importer_display':
-                            {'header': 'Mirrored e926 image by ' + uploader + ':\n\n'}}
+                            {'header': 'Mirrored ' + service + ' image by ' + uploader + ':\n\n'}}
                 image_url = img
             data['import_urls'] = [image_url]
             return data

--- a/plugins/e621.py
+++ b/plugins/e621.py
@@ -97,7 +97,7 @@ class E621Plugin:
                 json = callapi.json()
                 img = (json['file_url'])
                 uploader = json['author']
-                data = {'author': 'an e926 user',
+                data = {'author': uploader,
                         'source': url,
                         'importer_display':
                             {'header': 'Mirrored e926 image by ' + uploader + ':\n\n'}}


### PR DESCRIPTION
This pull requests resolves issue #20 by adding a plugin to add support for e621 and e926, which are both booru-based sites for furries. It does the following:
- Mirrors all images from e621 and e926 and its CDN
- Retrieves the uploader for non-CDN e621/e926 images
- Uses the e621/e926 API for uploading non-CDN links and a direct link for CDN links.
- Affects https://e621.net and https://e926.net (and their CDN and WWW subdomians)

This plugin is active on /u/TheMirrorPool and can be seen in action [here](https://www.reddit.com/r/heyitsshugatest/comments/4xeido/e926_api_mirror_thingy/d6eqyqs).
