### PR TITLE
Fixing Imgur .gif links by replacing the extension with .gifv

### DIFF
--- a/plugins/imgur.py
+++ b/plugins/imgur.py
@@ -129,15 +129,14 @@ class ImgurPlugin:
             if is_album:
                 results['link_display'] = '[Imgur Album](https://imgur.com/a/%s)  \n' % album['id']
             else:
-                
                 picture_url = images[0]['link'].replace('http', 'https')
                 r = requests.head(picture_url)
                 mime_text = r.headers.get('Content-Type')
                 mime = mimeparse.parse_mime_type(mime_text)
                 if mime[1] == 'gif':
                     picture_url = re.sub(r'(\.\w+)?$', '.gifv', picture_url)
-                
                 results['link_display'] = '[Imgur](%s)  \n' % picture_url
+
         except ImgurClientRateLimitError:
             self.log.error('Ran into imgur rate limit! %s', self.client.credits)
             return None

--- a/plugins/imgur.py
+++ b/plugins/imgur.py
@@ -128,7 +128,11 @@ class ImgurPlugin:
             if is_album:
                 results['link_display'] = '[Imgur Album](https://imgur.com/a/%s)  \n' % album['id']
             else:
-                results['link_display'] = '[Imgur](%s)  \n' % images[0]['link'].replace('http', 'https').replace('gif, 'gifv')
+                picture_url = images[0]['link'].replace('http', 'https')
+                with urllib.request.urlopen(picture_url) as response:
+                    if response.info().get_content_subtype() == 'gif':
+                        picture_url = picture_url.replace('gif', 'gifv')
+                results['link_display'] = '[Imgur](%s)  \n' % picture_url
         except ImgurClientRateLimitError:
             self.log.error('Ran into imgur rate limit! %s', self.client.credits)
             return None

--- a/plugins/imgur.py
+++ b/plugins/imgur.py
@@ -128,7 +128,7 @@ class ImgurPlugin:
             if is_album:
                 results['link_display'] = '[Imgur Album](https://imgur.com/a/%s)  \n' % album['id']
             else:
-                results['link_display'] = '[Imgur](%s)  \n' % images[0]['link'].replace('http', 'https')
+                results['link_display'] = '[Imgur](%s)  \n' % images[0]['link'].replace('http', 'https').replace('gif, 'gifv')
         except ImgurClientRateLimitError:
             self.log.error('Ran into imgur rate limit! %s', self.client.credits)
             return None

--- a/plugins/imgur.py
+++ b/plugins/imgur.py
@@ -24,6 +24,7 @@ import logging
 import urllib.request
 import urllib.error
 import traceback
+import mimeparse
 
 import imgurpython
 from imgurpython.helpers.error import ImgurClientRateLimitError
@@ -128,10 +129,14 @@ class ImgurPlugin:
             if is_album:
                 results['link_display'] = '[Imgur Album](https://imgur.com/a/%s)  \n' % album['id']
             else:
+                
                 picture_url = images[0]['link'].replace('http', 'https')
-                with urllib.request.urlopen(picture_url) as response:
-                    if response.info().get_content_subtype() == 'gif':
-                        picture_url = picture_url.replace('gif', 'gifv')
+                r = requests.head(picture_url)
+                mime_text = r.headers.get('Content-Type')
+                mime = mimeparse.parse_mime_type(mime_text)
+                if mime[1] == 'gif':
+                    picture_url = re.sub('\.gif|jpg|png', '.gifv', picture_url)
+                
                 results['link_display'] = '[Imgur](%s)  \n' % picture_url
         except ImgurClientRateLimitError:
             self.log.error('Ran into imgur rate limit! %s', self.client.credits)

--- a/plugins/imgur.py
+++ b/plugins/imgur.py
@@ -135,7 +135,7 @@ class ImgurPlugin:
                 mime_text = r.headers.get('Content-Type')
                 mime = mimeparse.parse_mime_type(mime_text)
                 if mime[1] == 'gif':
-                    picture_url = re.sub('\.gif|jpg|png', '.gifv', picture_url)
+                    picture_url = re.sub(r'(\.\w+)?$', '.gifv', picture_url)
                 
                 results['link_display'] = '[Imgur](%s)  \n' % picture_url
         except ImgurClientRateLimitError:


### PR DESCRIPTION
This won't affect any link except the ones that are .gifs. Because Lapis links to the direct image every time, and not the imgur page, this should work for every instance of a .gif.